### PR TITLE
feat: Add support for macos x64, linux Arm64 and macos Arm64

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,28 +1,18 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: macos-14
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
@@ -33,4 +23,4 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - run: brew install libpq
       - run: gradle wrapper --no-daemon
-      - run: ./gradlew build detekt --no-daemon -Ptargets=linuxX64
+      - run: ./gradlew build detekt --no-daemon -Ptargets=macosArm64

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -9,9 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: macos-14
-
+  test:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -22,7 +21,19 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - run: brew install libpq
-      - run: brew install docker colima
-      - run: colima start
       - run: gradle wrapper --no-daemon
-      - run: ./gradlew build detekt --no-daemon -Ptargets=macosArm64
+      - run: ./gradlew build detekt --no-daemon -Ptargets=linuxX64,linuxArm64
+  release:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - run: brew install libpq
+      - run: gradle wrapper --no-daemon
+      - run: ./gradlew build -x check --no-daemon -Ptargets=macosArm64

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -22,8 +22,8 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - run: brew install libpq
       - run: gradle wrapper --no-daemon
-      - run: ./gradlew build detekt --no-daemon -Ptargets=linuxX64,linuxArm64
-  release:
+      - run: ./gradlew build detekt --no-daemon -Ptargets=linuxX64
+  build:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -37,3 +37,29 @@ jobs:
       - run: brew install libpq
       - run: gradle wrapper --no-daemon
       - run: ./gradlew build -x check --no-daemon -Ptargets=macosArm64
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build
+  release:
+    runs-on: macos-14
+    needs:
+      - test
+      - build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - run: brew install libpq
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+      - run: gradle wrapper --no-daemon
+      - run: ./gradlew publishAllPublicationsToSonatypeRepository -x check --no-daemon

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -33,4 +33,4 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - run: brew install libpq
       - run: gradle wrapper --no-daemon
-      - run: ./gradlew build detekt --no-daemon
+      - run: ./gradlew build detekt --no-daemon -Ptargets=linuxX64

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -44,6 +44,8 @@ jobs:
           path: build
   release:
     runs-on: macos-14
+    # Disabled for now.
+    if: false
     needs:
       - test
       - build

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -22,5 +22,7 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - run: brew install libpq
+      - run: brew install docker colima
+      - run: colima start
       - run: gradle wrapper --no-daemon
       - run: ./gradlew build detekt --no-daemon -Ptargets=macosArm64

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PostgreSQL Kotlin/Native Driver
 ## Usage
 
 ```
-implementation("io.github.moreirasantos:pgkn:1.0.0")
+implementation("io.github.moreirasantos:pgkn:1.2.0")
 ```
 
 ```kotlin
@@ -83,3 +83,5 @@ TODO - clarify this better:
 1. https://stackoverflow.com/questions/64951024/how-can-i-run-two-isolated-installations-of-homebrew
 2. Two homebrews is good for macosarm and macosX, but it isn't enough for linuxX64
 3. For linuxX64 I had to brew install libpq in linux and copy over the files to macos
+4. https://discuss.kotlinlang.org/t/how-to-determine-linkeropts-at-build-time/17402/2
+5. https://github.com/JetBrains/kotlin-native/issues/1534

--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ fun main() {
 PGKN has a connection pool, its size being configurable in `PostgresDriver()` - 20 by default.  
 It will refresh connection units if the query fails fatally, but it still needs more fine-grained status checks.
 
-
-You can also use a single connection with `PostgresDriverUnit`, which currently is not `suspend`
-but probably will be in the future.
-
 ### Named Parameters
 
 ```kotlin
@@ -73,6 +69,17 @@ In JDBC, the placeholder would be `?` but with libpq, we will pass `$1`, `$2`, e
 
 This feature implementation tries to follow Spring's `NamedParameterJdbcTemplate` as close as possible.
 [NamedParameterJdbcTemplate](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.html)
+
+## Development
+
+### Local Build
+
+By default, this project will attempt to build for all targets. If you have a linux machine and only want to build
+the `linuxX64` and `linuxArm64` targets, you can do:
+
+```shell
+./gradlew build -Ptargets=linuxX64,linuxArm64
+```
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -73,3 +73,13 @@ In JDBC, the placeholder would be `?` but with libpq, we will pass `$1`, `$2`, e
 
 This feature implementation tries to follow Spring's `NamedParameterJdbcTemplate` as close as possible.
 [NamedParameterJdbcTemplate](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.html)
+
+## FAQ
+
+### Two HomeBrews
+
+TODO - clarify this better:
+
+1. https://stackoverflow.com/questions/64951024/how-can-i-run-two-isolated-installations-of-homebrew
+2. Two homebrews is good for macosarm and macosX, but it isn't enough for linuxX64
+3. For linuxX64 I had to brew install libpq in linux and copy over the files to macos

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,18 +68,20 @@ kotlin {
             }
         }
 
-        val jvmMain by getting {
-            dependencies {
-                implementation("org.springframework.data:spring-data-r2dbc:3.2.4")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.8.0")
-                implementation("org.postgresql:r2dbc-postgresql:1.0.4.RELEASE")
-                implementation("io.r2dbc:r2dbc-pool:1.0.1.RELEASE")
+        if (chosenTargets.contains("jvm")) {
+            val jvmMain by getting {
+                dependencies {
+                    implementation("org.springframework.data:spring-data-r2dbc:3.2.4")
+                    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.8.0")
+                    implementation("org.postgresql:r2dbc-postgresql:1.0.4.RELEASE")
+                    implementation("io.r2dbc:r2dbc-pool:1.0.1.RELEASE")
+                }
             }
-        }
-        val jvmTest by getting {
-            dependencies {
-                implementation("org.postgresql:r2dbc-postgresql:1.0.4.RELEASE")
-                implementation("org.jetbrains.kotlin:kotlin-test:1.9.23")
+            val jvmTest by getting {
+                dependencies {
+                    implementation("org.postgresql:r2dbc-postgresql:1.0.4.RELEASE")
+                    implementation("org.jetbrains.kotlin:kotlin-test:1.9.23")
+                }
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ kotlin.code.style=official
 kotlin.native.binary.sourceInfoType=libbacktrace
 kotlin.experimental.tryK2=true
 kapt.use.k2=true
+kotlin.mpp.enableCInteropCommonization=true

--- a/src/nativeInterop/cinterop/libpq.def
+++ b/src/nativeInterop/cinterop/libpq.def
@@ -1,6 +1,0 @@
-headers = libpq-fe.h
-headerFilter = *
-package = libpq
-
-compilerOpts = -I/home/linuxbrew/.linuxbrew/opt/libpq/include -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include
-linkerOpts = -L/home/linuxbrew/.linuxbrew/opt/libpq/lib -L/opt/homebrew/opt/libpq/lib -L/usr/local/opt/libpq/lib -lpq

--- a/src/nativeInterop/cinterop/libpqArm.def
+++ b/src/nativeInterop/cinterop/libpqArm.def
@@ -1,0 +1,6 @@
+headers = libpq-fe.h
+headerFilter = *
+package = libpq
+
+compilerOpts = -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include
+linkerOpts = -L/opt/homebrew/opt/libpq/lib -L/usr/local/opt/libpq/lib -lpq

--- a/src/nativeInterop/cinterop/libpqX.def
+++ b/src/nativeInterop/cinterop/libpqX.def
@@ -1,0 +1,6 @@
+headers = libpq-fe.h
+headerFilter = *
+package = libpq
+
+compilerOpts = -I/usr/local/opt/libpq/include
+linkerOpts = -L/usr/local/opt/libpq/lib -lpq

--- a/src/nativeInterop/cinterop/libpqlinuxX.def
+++ b/src/nativeInterop/cinterop/libpqlinuxX.def
@@ -2,6 +2,6 @@ headers = libpq-fe.h
 headerFilter = libpq-fe.h
 package = libpq
 
-compilerOpts = -I/usr/local/opt/linux/libpq/include -I/usr/local/opt/libpq/include
-linkerOpts = -L/usr/local/opt/linux/libpq/lib -L/usr/local/opt/libpq/lib -lpq
+compilerOpts = -I/usr/local/opt/linux/libpq/include -I/usr/local/opt/libpq/include -I/home/linuxbrew/.linuxbrew/opt/libpq/include
+linkerOpts = -L/usr/local/opt/linux/libpq/lib -L/usr/local/opt/libpq/lib -L/home/linuxbrew/.linuxbrew/opt/libpq/lib -lpq
 

--- a/src/nativeInterop/cinterop/libpqlinuxX.def
+++ b/src/nativeInterop/cinterop/libpqlinuxX.def
@@ -2,6 +2,6 @@ headers = libpq-fe.h
 headerFilter = libpq-fe.h
 package = libpq
 
-compilerOpts = -I/usr/local/opt/linux/libpq/include
-linkerOpts = -L/usr/local/opt/linux/libpq/lib -lpq
+compilerOpts = -I/usr/local/opt/linux/libpq/include -I/usr/local/opt/libpq/include
+linkerOpts = -L/usr/local/opt/linux/libpq/lib -L/usr/local/opt/libpq/lib -lpq
 

--- a/src/nativeInterop/cinterop/libpqlinuxX.def
+++ b/src/nativeInterop/cinterop/libpqlinuxX.def
@@ -1,0 +1,7 @@
+headers = libpq-fe.h
+headerFilter = libpq-fe.h
+package = libpq
+
+compilerOpts = -I/usr/local/opt/linux/libpq/include
+linkerOpts = -L/usr/local/opt/linux/libpq/lib -lpq
+


### PR DESCRIPTION
A machine with all versions of libpq installed (arm64, macosX64 and macosArm64) in the proper folders (see .def files) will now be able to run all targets.

This is a stepping stone to fetch and store headers/binaries of libpq so that a machine doesn't need to install different versions.